### PR TITLE
feat: Update JWT configuration and enhance Solicitud validation process

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -32,14 +32,16 @@ security:
   oauth2:
     resource-server:
       jwt:
-        jwk-set-uri: "${HOST)"
+        jwk-set-uri: http://localhost:8080/.well-known/jwks.json
   jwt:
-    issuer: "${ISSU}"
+    issuer: crediya-auth
 logging:
   level:
     org.springframework.security: DEBUG
-    org.springframework.security.oauth2: DEBUG
-    org.springframework.web.reactive.function.client.ExchangeFunctions: INFO
+    com.nimbusds.jose: DEBUG
+    com.nimbusds.jose.jwk: DEBUG
+    reactor.netty.http.client: DEBUG
+
 
 management:
   endpoints:

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/config/JwtDecoderConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/config/JwtDecoderConfig.java
@@ -1,6 +1,8 @@
 package co.com.crediya.api.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
@@ -8,8 +10,10 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
+@Slf4j
 public class JwtDecoderConfig {
 
     @Bean
@@ -24,5 +28,14 @@ public class JwtDecoderConfig {
             decoder.setJwtValidator(withIssuer);
         }
         return decoder;
+    }
+
+    @Bean
+    ApplicationRunner jwksProbe(@Value("${security.oauth2.resource-server.jwt.jwk-set-uri:}") String uri) {
+        return args -> WebClient.create().get().uri(uri)
+                .retrieve().bodyToMono(String.class)
+                .doOnNext(b -> log.info("JWKS ok: {}", b.substring(0, Math.min(b.length(), 80))+"..."))
+                .doOnError(e -> log.error("JWKS ERROR {}", e.toString()))
+                .subscribe();
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/solicitud/SolicitudHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/solicitud/SolicitudHandler.java
@@ -29,6 +29,7 @@ public class SolicitudHandler {
                     String emailFromToken = auth.getToken().getSubject();
                     String documento = (String) auth.getTokenAttributes().get("doc");
                     return req.bodyToMono(RegistroSolicitudRequestDto.class)
+                            .flatMap(validarSolicitud::validate)
                             .map(dto -> mapperDto.toUseCae(dto, emailFromToken, documento))
                             .flatMap(useCase::registrarSolicitud)
                             .map(mapperDto::toResponse)


### PR DESCRIPTION
This pull request introduces several important improvements related to JWT authentication configuration, diagnostics, and request validation. The main changes include updating the JWT issuer and JWKS URI in the configuration, enhancing logging for JWT-related components, adding a runtime probe to verify JWKS availability, and strengthening request validation logic.

**Security and JWT Configuration Updates:**

* Updated the `jwk-set-uri` to use a local JWKS endpoint (`http://localhost:8080/.well-known/jwks.json`) and set the JWT issuer to `crediya-auth` in `application.yaml` for improved clarity and local development compatibility.
* Enhanced logging configuration to include detailed debug output for JWT processing libraries (`com.nimbusds.jose`, `com.nimbusds.jose.jwk`, and `reactor.netty.http.client`) for better diagnostics.

**Diagnostics and Monitoring:**

* Added an `ApplicationRunner` bean in `JwtDecoderConfig.java` that probes the JWKS endpoint at application startup, logging the result or any errors to help detect misconfigurations early.

**Validation Improvements:**

* Strengthened the request handling in `SolicitudHandler.java` by introducing a validation step (`validarSolicitud::validate`) before processing incoming requests, ensuring only valid data is handled.

**Codebase Enhancements:**

* Introduced Lombok's `@Slf4j` annotation in `JwtDecoderConfig.java` to simplify logging code and improve maintainability.